### PR TITLE
[t-mr1] vendor: etc: camera: Enable multi camera framework

### DIFF
--- a/rootdir/vendor/etc/camera/camxoverridesettings.txt
+++ b/rootdir/vendor/etc/camera/camxoverridesettings.txt
@@ -3,3 +3,5 @@ logPerfInfoMask=0
 logVerboseMask=0
 logWarningMask=0
 systemLogEnable=TRUE
+
+multiCameraEnable=TRUE


### PR DESCRIPTION
Enable multi camera framework with Back Aux camera.
Required to enable tele/uwide sensors.

W CHIUSECASE: [WARN   ] chxlogicalcameras.h:438 isDeviceAvailable()
Can't build "MultiCamera". MultiCamera isn't enabled and number of
physical cameras is 2