### PR TITLE
platform: add hvdcp service

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -226,6 +226,10 @@ PRODUCT_PACKAGES += \
     hwcomposer.sm6375 \
     memtrack.default
 
+# HVDCP init
+PRODUCT_PACKAGES += \
+    hvdcp_opti.rc
+
 # Keymaster 4 passthrough service init file
 # (executable is on odm)
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Needed for battery capacity to update. Should be added to t-mr1 and u-mr1 branches also, the needed hvdcp_opti binary is already in vendor release of Android 13 but not yet in Android 14.